### PR TITLE
Support for alga library [WIP]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ license = "Apache-2.0"
 
 [dependencies]
 num-traits = "^0.1.35"
+approx = "^0.1.1"
+alga = { version = "^0.5.2", optional = true }
+alga_derive = { version = "^0.5.1", optional = true }
+
+[features]
+algebra = ["alga", "alga_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,12 @@
 //! ```
 
 extern crate num_traits;
+extern crate approx;
+#[cfg(feature = "algebra")]
+extern crate alga;
+#[cfg(feature = "algebra")]
+#[macro_use]
+extern crate alga_derive;
 
 mod float_impl;
 pub mod checkers;
@@ -87,6 +93,9 @@ pub mod prelude {
 use std::marker::PhantomData;
 use std::fmt;
 use num_traits::Float;
+
+#[cfg(feature = "algebra")]
+use alga::general::{Additive, Multiplicative};
 
 /// Trait for checking whether a floating point number is *valid*.
 ///
@@ -120,6 +129,8 @@ pub trait FloatChecker<F> {
 /// The exception to this rule is for methods that return an `Option` containing
 /// a `NoisyFloat`, in which case the result would be `None` if the value is invalid.
 #[repr(C)]
+#[cfg_attr(feature = "algebra", derive(Alga))]
+#[cfg_attr(feature = "algebra", alga_traits(Field(Additive, Multiplicative)))]
 pub struct NoisyFloat<F: Float, C: FloatChecker<F>> {
     value: F,
     checker: PhantomData<C>


### PR DESCRIPTION
This is needed to be able to use noisy float with nalgebra.

- [ ] Generating quickcheck tests with the `alga_derive` chokes on something.
- [ ] There is quite bit of boilerplate implementation which could be automated. (`alga` contains some macros that are used for similar stuff that could maybe be made public)

(Apparently I failed and didn't branch from master so this contains the repr changes.. Oh well)