### PR TITLE
Implement std::iter::{Sum, Product} for NoisyFloat<C, F>

### DIFF
--- a/src/float_impl.rs
+++ b/src/float_impl.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::iter;
 use std::ops::{Add, Sub, Mul, Div, Rem, AddAssign, SubAssign, MulAssign, DivAssign, RemAssign, Neg};
 use std::num::FpCategory;
 use num_traits::{Float, Num, FloatConst};
@@ -269,4 +270,26 @@ impl<F: Float + FloatConst, C: FloatChecker<F>> FloatConst for NoisyFloat<F, C> 
     #[inline] fn LOG2_E() -> Self { Self::new(F::LOG2_E()) }
     #[inline] fn PI() -> Self { Self::new(F::PI()) }
     #[inline] fn SQRT_2() -> Self { Self::new(F::SQRT_2()) }
+}
+
+impl<F: Float, C: FloatChecker<F>> iter::Sum for NoisyFloat<F, C> {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        // the sum of a finite list of reals must be real,
+        // and the sum of a finite list of non-NaN must be non-NaN
+        Self::unchecked_new(iter.map(|i| i.raw()).fold(F::zero(), |acc, i| acc + i))
+    }
+}
+
+impl<F: Float, C: FloatChecker<F>> iter::Product for NoisyFloat<F, C> {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        // the product of a finite list of reals must be real,
+        // and the product of a finite list of non-NaN must be non-NaN
+        Self::unchecked_new(iter.map(|i| i.raw()).fold(F::one(), |acc, i| acc * i))
+    }
 }

--- a/src/float_impl.rs
+++ b/src/float_impl.rs
@@ -277,9 +277,7 @@ impl<F: Float, C: FloatChecker<F>> iter::Sum for NoisyFloat<F, C> {
     where
         I: Iterator<Item = Self>,
     {
-        // the sum of a finite list of reals must be real,
-        // and the sum of a finite list of non-NaN must be non-NaN
-        Self::unchecked_new(iter.map(|i| i.raw()).fold(F::zero(), |acc, i| acc + i))
+        Self::new(iter.map(|i| i.raw()).fold(F::zero(), |acc, i| acc + i))
     }
 }
 
@@ -288,8 +286,6 @@ impl<F: Float, C: FloatChecker<F>> iter::Product for NoisyFloat<F, C> {
     where
         I: Iterator<Item = Self>,
     {
-        // the product of a finite list of reals must be real,
-        // and the product of a finite list of non-NaN must be non-NaN
-        Self::unchecked_new(iter.map(|i| i.raw()).fold(F::one(), |acc, i| acc * i))
+        Self::new(iter.map(|i| i.raw()).fold(F::one(), |acc, i| acc * i))
     }
 }


### PR DESCRIPTION
Closes #7.

Allows the use of `iter.sum()` and `iter.product` where `iter<Item=NoisyFloat>`.