### PR TITLE
Add Signed trait implementation

### DIFF
--- a/src/float_impl.rs
+++ b/src/float_impl.rs
@@ -18,7 +18,7 @@ use std::ops::{Add, Sub, Mul, Div, Rem, AddAssign, SubAssign, MulAssign, DivAssi
 use std::num::FpCategory;
 use std::hash::{Hash, Hasher};
 use std::mem::transmute;
-use num_traits::{Float, Num, FloatConst};
+use num_traits::{Float, Num, FloatConst, Signed};
 use num_traits::cast::{NumCast, ToPrimitive};
 use num_traits::identities::{Zero, One};
 use ::{FloatChecker, NoisyFloat};
@@ -299,6 +299,14 @@ impl<F: Float + FloatConst, C: FloatChecker<F>> FloatConst for NoisyFloat<F, C> 
     #[inline] fn LOG2_E() -> Self { Self::new(F::LOG2_E()) }
     #[inline] fn PI() -> Self { Self::new(F::PI()) }
     #[inline] fn SQRT_2() -> Self { Self::new(F::SQRT_2()) }
+}
+
+impl<F: Float + Signed, C: FloatChecker<F>> Signed for NoisyFloat<F, C> {
+    #[inline] fn abs(&self) -> Self { Self::new(self.value.abs()) }
+    #[inline] fn abs_sub(&self, other: &Self) -> Self { Self::new(self.value.abs_sub(other.value)) }
+    #[inline] fn signum(&self) -> Self { Self::new(self.value.signum()) }
+    #[inline] fn is_positive(&self) -> bool { self.value.is_positive() }
+    #[inline] fn is_negative(&self) -> bool { self.value.is_negative() }
 }
 
 impl<F: Float, C: FloatChecker<F>> iter::Sum for NoisyFloat<F, C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! but during a release run there is *no overhead* for using these floating
 //! point types compared to using `f32` or `f64` directly.
 //!
-//! This crate makes use of the floating point and number traits in the
+//! This crate makes use of the number, signed and floating point traits in the
 //! popular `num_traits` crate.
 //!
 //! #Examples


### PR DESCRIPTION
Would it be possible to implement the [Signed](https://rust-num.github.io/num/num/trait.Signed.html) trait for noisy floats as well? This would be consistent with the way f32 and f64 types are treated in the num crate currently. 