### PR TITLE
Change NoisyFloat from repr(C) to repr(transparent)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub trait FloatChecker<F> {
 /// as defined by the float checker.
 /// The exception to this rule is for methods that return an `Option` containing
 /// a `NoisyFloat`, in which case the result would be `None` if the value is invalid.
-#[repr(C)]
+#[repr(transparent)]
 pub struct NoisyFloat<F: Float, C: FloatChecker<F>> {
     value: F,
     checker: PhantomData<C>


### PR DESCRIPTION
This is more convenient for FFI. See [RFC 1758](https://github.com/rust-lang/rfcs/blob/master/text/1758-repr-transparent.md) for details. `#[repr(transparent)]` was added in Rust 1.28.