### PR TITLE
Add conversions for references

### DIFF
--- a/src/float_impl.rs
+++ b/src/float_impl.rs
@@ -29,6 +29,12 @@ impl<F: Float, C: FloatChecker<F>> Clone for NoisyFloat<F, C> {
 
 impl<F: Float, C: FloatChecker<F>> Copy for NoisyFloat<F, C> {}
 
+impl<F: Float, C: FloatChecker<F>> AsRef<F> for NoisyFloat<F, C> {
+    fn as_ref(&self) -> &F {
+        &self.value
+    }
+}
+
 impl<F: Float, C: FloatChecker<F>> PartialEq<F> for NoisyFloat<F, C> {
     #[inline] fn eq(&self, other: &F) -> bool { self.value.eq(&other) }
 }


### PR DESCRIPTION
This makes it possible to convert a reference to/from the `NoisyFloat` wrapper in-place. This is especially useful for functions operating on generic slices `&[T]`, where only a reference to a value may be available.