### PR TITLE
Implement From<NoisyFloat> for f32 and f64

### DIFF
--- a/src/float_impl.rs
+++ b/src/float_impl.rs
@@ -18,6 +18,7 @@ use std::ops::{Add, Sub, Mul, Div, Rem, AddAssign, SubAssign, MulAssign, DivAssi
 use std::num::FpCategory;
 use std::hash::{Hash, Hasher};
 use std::mem::transmute;
+use std::convert::From;
 use num_traits::{Bounded, Float, Num, FloatConst, Signed};
 use num_traits::cast::{NumCast, FromPrimitive, ToPrimitive};
 use num_traits::identities::{Zero, One};
@@ -338,6 +339,24 @@ impl<F: Float + FromPrimitive, C: FloatChecker<F>> FromPrimitive for NoisyFloat<
 
 impl<F: Float, C: FloatChecker<F>> NumCast for NoisyFloat<F, C> {
     #[inline] fn from<T: ToPrimitive>(n: T) -> Option<Self> { F::from(n).and_then(|v| Self::try_new(v)) }
+}
+
+impl<C: FloatChecker<f32>> From<NoisyFloat<f32, C>> for f32 {
+    #[inline] fn from(n: NoisyFloat<f32, C>) -> Self {
+        n.value
+    }
+}
+
+impl<C: FloatChecker<f64>> From<NoisyFloat<f64, C>> for f64 {
+    #[inline] fn from(n: NoisyFloat<f64, C>) -> Self {
+        n.value
+    }
+}
+
+impl<C: FloatChecker<f32>> From<NoisyFloat<f32, C>> for f64 {
+    #[inline] fn from(n: NoisyFloat<f32, C>) -> Self {
+        n.value as f64
+    }
 }
 
 impl<F: Float, C: FloatChecker<F>> Float for NoisyFloat<F, C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,13 @@ mod tests {
     }
 
     #[test]
+    fn test_convert() {
+        assert_eq!(f32::from(r32(3.0)), 3.0f32);
+        assert_eq!(f64::from(r32(5.0)), 5.0f64);
+        assert_eq!(f64::from(r64(7.0)), 7.0f64);
+    }
+
+    #[test]
     #[cfg(debug_assertions)]
     #[should_panic]
     fn n64_nan() {


### PR DESCRIPTION
Unfortunately it's not possible under Rust's current coherence rules to implement `From<NoisyFloat<F, C>>` for generic `F` (it gives error [E0210](https://doc.rust-lang.org/error-index.html#E0210)). But we can still provide the implementation for concrete types like `f32` and `f64` (and most of the time, `F` will actually be either `f32` or `f64`). That's what this PR does.

This PR also implements the widening conversion `From<NoisyFloat<f32, C>>` for `f64`, to be consistent with the Rust standard library, which also implements `From<f32>` for `f64`.

While converting `NoisyFloat` to raw floats is already possible with either the `raw()` method or the `to_f64()` (and similar) functions, the benefit of implementing the standard library's conversion methods is that people don't have to search the docs to find them (see also issue #23). They can write `f64::from(x)` or `x.into()` and it just works.