### PR TITLE
Add `Nn{32, 64}` types for non-negative floats

### DIFF
--- a/src/checkers.rs
+++ b/src/checkers.rs
@@ -58,3 +58,36 @@ impl<F: Float> From<NoisyFloat<F, FiniteChecker>> for NoisyFloat<F, NumChecker> 
         Self::unchecked_new_generic(value.raw())
     }
 }
+
+/// A `FloatChecker` that considers any finite, non-negative values valid.
+///
+/// Zero and positive finite values are okay, anything else (negative, infinite, NaN) is invalid.
+///
+/// The `assert` method is implemented using `debug_assert!`.
+pub struct NonNegativeChecker;
+
+impl<F: Float> FloatChecker<F> for NonNegativeChecker {
+    #[inline]
+    fn assert(value: F) {
+        debug_assert!(value.is_finite(), "unexpected NaN or infinity");
+        debug_assert!(!value.is_sign_negative(), "unexpected negative number");
+    }
+
+    #[inline]
+    fn check(value: F) -> bool {
+        value.is_finite() && !value.is_sign_negative()
+    }
+}
+
+impl<F: Float> From<NoisyFloat<F, NonNegativeChecker>> for NoisyFloat<F, FiniteChecker> {
+    #[inline]
+    fn from(value: NoisyFloat<F, NonNegativeChecker>) -> Self {
+        Self::unchecked_new_generic(value.raw())
+    }
+}
+impl<F: Float> From<NoisyFloat<F, NonNegativeChecker>> for NoisyFloat<F, NumChecker> {
+    #[inline]
+    fn from(value: NoisyFloat<F, NonNegativeChecker>) -> Self {
+        Self::unchecked_new_generic(value.raw())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,10 @@ mod tests {
         assert_eq!(N64::try_borrowed(&f64::NAN), None);
         let mut nan = f64::NAN;
         assert_eq!(N64::try_borrowed_mut(&mut nan), None);
+        assert_eq!(Nn64::try_new(f64::INFINITY), None);
+        assert_eq!(Nn64::try_new(f64::NAN), None);
+        assert_eq!(Nn64::try_new(-1.0), None);
+        assert!(Nn64::try_new(f64::MAX).is_some());
     }
 
     #[test]
@@ -415,6 +419,27 @@ mod tests {
     #[should_panic]
     fn r64_infinity() {
         let _ = r64(1.0) / r64(0.0);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn nn64_nan() {
+        let _ = nn64(0.0) / nn64(0.0);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn nn64_infinity() {
+        let _ = nn64(1.0) / nn64(0.0);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic]
+    fn nn64_neg() {
+        let _ = nn64(0.0) - nn64(1.0);
     }
 
     #[test]
@@ -563,15 +588,21 @@ mod tests {
         const B: N64 = N64::unchecked_new(2.0);
         const C: R32 = R32::unchecked_new(3.0);
         const D: R64 = R64::unchecked_new(4.0);
+        const E: Nn32 = Nn32::unchecked_new(5.0);
+        const F: Nn64 = Nn64::unchecked_new(6.0);
 
         const A_RAW: f32 = A.const_raw();
         const B_RAW: f64 = B.const_raw();
         const C_RAW: f32 = C.const_raw();
         const D_RAW: f64 = D.const_raw();
+        const E_RAW: f32 = E.const_raw();
+        const F_RAW: f64 = F.const_raw();
 
         assert_eq!(A_RAW, 1.0);
         assert_eq!(B_RAW, 2.0);
         assert_eq!(C_RAW, 3.0);
         assert_eq!(D_RAW, 4.0);
+        assert_eq!(E_RAW, 5.0);
+        assert_eq!(F_RAW, 6.0);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,7 +20,7 @@
 
 use core::marker::PhantomData;
 use crate::{
-    checkers::{FiniteChecker, NumChecker},
+    checkers::{FiniteChecker, NonNegativeChecker, NumChecker},
     NoisyFloat,
 };
 
@@ -48,6 +48,16 @@ pub type R32 = NoisyFloat<f32, FiniteChecker>;
 /// numbers do not include NaN or +/- Infinity.
 pub type R64 = NoisyFloat<f64, FiniteChecker>;
 
+/// A floating point number behaving like `f32` that does not allow negative values, NaN, or Infinity.
+///
+/// The "Nn" in the name stands for "non-negative".
+pub type Nn32 = NoisyFloat<f32, NonNegativeChecker>;
+
+/// A floating point number behaving like `f64` that does not allow negative values, NaN, or Infinity.
+///
+/// The "Nn" in the name stands for "non-negative".
+pub type Nn64 = NoisyFloat<f64, NonNegativeChecker>;
+
 /// Shorthand for `N32::new(value)`.
 #[inline]
 pub fn n32(value: f32) -> N32 {
@@ -70,6 +80,18 @@ pub fn r32(value: f32) -> R32 {
 #[inline]
 pub fn r64(value: f64) -> R64 {
     R64::new(value)
+}
+
+/// Shorthand for `NN32::new(value)`.
+#[inline]
+pub fn nn32(value: f32) -> Nn32 {
+    Nn32::new(value)
+}
+
+/// Shorthand for `NN64::new(value)`.
+#[inline]
+pub fn nn64(value: f64) -> Nn64 {
+    Nn64::new(value)
 }
 
 macro_rules! const_fns {
@@ -100,3 +122,5 @@ const_fns!(N32, f32);
 const_fns!(N64, f64);
 const_fns!(R32, f32);
 const_fns!(R64, f64);
+const_fns!(Nn32, f32);
+const_fns!(Nn64, f64);


### PR DESCRIPTION
Note that I named it `Nn64` in order to stay consistent with Rust's camelCase conventions, which state that acronyms should be treated as a single word. If you think this looks strange, I can change it to `NN64`.