### PR TITLE
Bump criterion dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ approx = { version = "0.4", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 serde_derive = "1.0"
-criterion = "0.3"
+criterion = "0.4"
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
I am packaging the `noisy_float` crate for fedora and for the build to succeed the criterion dependency needs to be updated to version 0.4.

I ran the tests locally and all of them succeeded.