### PR TITLE
Bump approx version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1.0", optional = true }
-approx = { version = "0.4", optional = true }
+approx = { version = "0.5", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
I am packaging the noisy_float crate for fedora and for the build to succeed the approx dependency needs to be updated to version 0.5.

I ran the tests locally and all of them succeeded.
